### PR TITLE
Escape URL query string for searching.

### DIFF
--- a/trove/src/bamboo/trove/common/DocumentStatus.java
+++ b/trove/src/bamboo/trove/common/DocumentStatus.java
@@ -20,5 +20,18 @@ public enum DocumentStatus {
   NOT_APPLICABLE,
   RESTRICTED_FOR_DELIVERY,
   RESTRICTED_FOR_DISCOVERY,
-  RESTRICTED_FOR_BOTH
+  RESTRICTED_FOR_BOTH;
+  
+  public static DocumentStatus status(Boolean deliverable, Boolean discoverable){
+  	if((deliverable!=null && !deliverable) && (discoverable != null && !discoverable)){
+  		return RESTRICTED_FOR_BOTH;
+  	}
+  	if(deliverable!=null && !deliverable){
+  		return RESTRICTED_FOR_DELIVERY;
+  	}
+  	if(discoverable!=null && !discoverable){
+  		return RESTRICTED_FOR_DISCOVERY;
+  	}
+  	return ACCEPTED;
+  }
 }

--- a/trove/src/bamboo/trove/rule/RuleChangeUpdateManager.java
+++ b/trove/src/bamboo/trove/rule/RuleChangeUpdateManager.java
@@ -54,6 +54,7 @@ import au.gov.nla.trove.indexer.api.AcknowledgeWorker;
 import au.gov.nla.trove.indexer.api.EndPointDomainManager;
 import au.gov.nla.trove.indexer.api.WorkProcessor;
 import bamboo.trove.common.BaseWarcDomainManager;
+import bamboo.trove.common.DocumentStatus;
 import bamboo.trove.common.EndPointRotator;
 import bamboo.trove.common.LastRun;
 import bamboo.trove.common.SolrEnum;
@@ -70,7 +71,7 @@ public class RuleChangeUpdateManager extends BaseWarcDomainManager implements Ru
 
   private static final String[] SOLR_FIELDS = new String[] {SolrEnum.ID.toString(), SolrEnum.DISPLAY_URL.toString(),
           SolrEnum.DELIVERY_URL.toString(), SolrEnum.DATE.toString(), SolrEnum.BOOST.toString(),
-          SolrEnum.RULE.toString()};
+          SolrEnum.RULE.toString(), SolrEnum.DELIVERABLE.toString(), SolrEnum.DISCOVERABLE.toString()};
   private static final SimpleDateFormat format = new SimpleDateFormat("yyy-MM-dd'T'HH:mm:ss'Z'");
   private static int NUMBER_OF_WORKERS = 5;
   private static final ZoneId TZ = ZoneId.systemDefault();
@@ -654,9 +655,11 @@ public class RuleChangeUpdateManager extends BaseWarcDomainManager implements Ru
       Date capture = (Date) doc.getFieldValue(SolrEnum.DATE.toString());
       float boost = (Float) doc.getFieldValue(SolrEnum.BOOST.toString());
       int ruleId = (Integer) doc.getFieldValue(SolrEnum.RULE.toString());
-
-      RuleRecheckWorker worker = new RuleRecheckWorker(id, deliveryUrl, capture, ruleId, boost,
-              workLog, manager, restrictionsService);
+      Boolean deliverable = (Boolean) doc.getFieldValue(SolrEnum.DELIVERABLE.toString());
+      Boolean discoverable = (Boolean) doc.getFieldValue(SolrEnum.DELIVERABLE.toString());
+      DocumentStatus currentPolicy = DocumentStatus.status(deliverable, discoverable);
+      RuleRecheckWorker worker = new RuleRecheckWorker(id, deliveryUrl, capture, ruleId, 
+      		currentPolicy,boost, workLog, manager, restrictionsService);
 
       workProcessor.process(worker);
     }

--- a/trove/src/bamboo/trove/rule/RuleChangeUpdateManager.java
+++ b/trove/src/bamboo/trove/rule/RuleChangeUpdateManager.java
@@ -35,6 +35,7 @@ import org.apache.solr.client.solrj.SolrQuery.SortClause;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
@@ -546,7 +547,9 @@ public class RuleChangeUpdateManager extends BaseWarcDomainManager implements Ru
   			url = url.substring(0, url.length()-1);
   		}
   	}
-    return SolrEnum.URL_TOKENIZED + ":" + CdxAccessControl.getSearchUrl(url);
+  	url = CdxAccessControl.getSearchUrl(url);
+  	url = ClientUtils.escapeQueryChars(url);
+    return SolrEnum.URL_TOKENIZED + ":" + url;
   }
 
   private WorkLog findDocumentsNewRule(CdxRule newRule, String notLastIndexed) throws SolrServerException, IOException {

--- a/trove/test/bamboo/trove/common/DocumentStatusTest.java
+++ b/trove/test/bamboo/trove/common/DocumentStatusTest.java
@@ -1,0 +1,35 @@
+package bamboo.trove.common;
+
+import static org.junit.Assert.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DocumentStatusTest{
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception{
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception{
+	}
+
+	/**
+	 * Test for converting from solr doc back to policy.
+	 */
+	@Test
+	public void testStatus(){
+		assertEquals(DocumentStatus.ACCEPTED, DocumentStatus.status(null, null));
+		assertEquals(DocumentStatus.RESTRICTED_FOR_BOTH, DocumentStatus.status(false, false));
+		assertEquals(DocumentStatus.RESTRICTED_FOR_DELIVERY, DocumentStatus.status(false, null));
+		assertEquals(DocumentStatus.RESTRICTED_FOR_DISCOVERY, DocumentStatus.status(null, false));
+		assertEquals(DocumentStatus.ACCEPTED, DocumentStatus.status(true, true));
+		assertEquals(DocumentStatus.ACCEPTED, DocumentStatus.status(true, null));
+		assertEquals(DocumentStatus.ACCEPTED, DocumentStatus.status(null, true));
+		assertEquals(DocumentStatus.RESTRICTED_FOR_DISCOVERY, DocumentStatus.status(true, false));
+		assertEquals(DocumentStatus.RESTRICTED_FOR_DELIVERY, DocumentStatus.status(false, true));
+	}
+
+}

--- a/trove/test/bamboo/trove/services/CdxRestrictionServiceTest.java
+++ b/trove/test/bamboo/trove/services/CdxRestrictionServiceTest.java
@@ -246,8 +246,8 @@ public class CdxRestrictionServiceTest {
     SolrQuery query = manager.convertRuleToSearch(ruleSet.getRules().get(1144L), "");
     boolean found = false;
     // We do not want to see *:* on the end
-    String target = "(" + SolrEnum.URL_TOKENIZED + ":pandora.nla.gov.au/pan/35531/) OR ("
-            + SolrEnum.URL_TOKENIZED + ":adultshop.com.au/)";
+    String target = "(" + SolrEnum.URL_TOKENIZED + ":pandora.nla.gov.au\\/pan\\/35531\\/) OR ("
+            + SolrEnum.URL_TOKENIZED + ":adultshop.com.au\\/)";
     for (String fq : query.getFilterQueries()) {
       if (target.equals(fq)) {
         found = true;


### PR DESCRIPTION
We need to escape the url when querying solr as one of the rules caused an error.